### PR TITLE
Cleaner errors

### DIFF
--- a/pgpdump/data.py
+++ b/pgpdump/data.py
@@ -23,13 +23,15 @@ class BinaryData(object):
         self.data = data
         self.length = len(data)
 
-    def packets(self):
-        '''A generator function returning PGP data packets.'''
+    def packets(self, skip=False):
+        '''A generator function returning PGP data packets.
+        if skip=True, failing packets will log an error instead of raising an exception.'''
         offset = 0
         while offset < self.length:
-            total_length, packet = construct_packet(self.data, offset)
+            total_length, packet = construct_packet(self.data, offset, skip)
             offset += total_length
-            yield packet
+            if packet is not None:
+                yield packet
 
     def __repr__(self):
         return "<%s: length %d>" % (

--- a/pgpdump/packet.py
+++ b/pgpdump/packet.py
@@ -4,7 +4,8 @@ from math import ceil, log
 import re
 import logging
 
-from .utils import (PgpdumpException, get_int2, get_int4, get_mpi,
+from .utils import (PgpdumpException, encode_packet,
+                    get_int2, get_int4, get_mpi,
         get_key_id, get_hex_data, get_int_bytes, pack_data)
 
 
@@ -883,8 +884,7 @@ def construct_packet(data, header_start, skip=False):
         packet = PacketType(tag, name, new, packet_data)
     except PgpdumpException as e:
         if skip:
-            # FIXME: assmeble the packet structure and add it to the warning in ascii-armored form
-            logging.warning(e)
+            logging.warning(str(e) + '\n' + encode_packet(tag, new, packet_data, armored=True))
         else:
             raise
     return (consumed, packet)

--- a/pgpdump/packet.py
+++ b/pgpdump/packet.py
@@ -669,6 +669,9 @@ class UserAttributePacket(Packet):
             sub_offset, sub_len, sub_part = new_tag_length(self.data, offset)
             # sub_len includes the subtype single byte, knock that off
             sub_len -= 1
+            if offset + sub_offset >= len(self.data):
+                raise PgpdumpException("Attribute at position %d wants another %d octets, but only %d octets remain"%(
+                    offset, sub_offset, len(self.data) - offset))
             # initial length bytes
             offset += sub_offset
 

--- a/pgpdump/packet.py
+++ b/pgpdump/packet.py
@@ -576,7 +576,7 @@ class SecretKeyPacket(PublicKeyPacket):
                             "Unsupported GnuPG S2K extension, encountered mode %d" % mode)
             else:
                 raise PgpdumpException(
-                        "Unsupported public key algorithm %d" % s2k_type_id)
+                        "Unsupported S2K algorithm %d" % s2k_type_id)
 
             if s2k_length != (offset - offset_before_s2k):
                 raise PgpdumpException(

--- a/pgpdump/packet.py
+++ b/pgpdump/packet.py
@@ -46,6 +46,7 @@ class AlgoLookup(object):
         19: "ECDSA",
         20: "Formerly ElGamal Encrypt or Sign",
         21: "Diffie-Hellman",
+        22: "EdDSA",
     }
 
     @classmethod

--- a/pgpdump/packet.py
+++ b/pgpdump/packet.py
@@ -144,6 +144,7 @@ class SignatureSubpacket(object):
         30: "Features",
         31: "Signature Target",
         32: "Embedded Signature",
+        33: "Issuer Fingerprint",
     }
 
     @property
@@ -173,6 +174,8 @@ class SignaturePacket(Packet, AlgoLookup):
         self.raw_expiration_time = None
         self.expiration_time = None
         self.key_id = None
+        self.fingerprint = None
+        self.fingerprint_version = None
         self.hash2 = None
         self.subpackets = []
         super(SignaturePacket, self).__init__(*args, **kwargs)
@@ -276,6 +279,9 @@ class SignaturePacket(Packet, AlgoLookup):
                 self.raw_expiration_time = get_int4(subpacket.data, 0)
             elif subpacket.subtype == 16:
                 self.key_id = get_key_id(subpacket.data, 0)
+            elif subpacket.subtype == 33:
+                self.fingerprint_version = int(subpacket.data[0])
+                self.fingerprint = get_hex_data(subpacket.data, 1, len(subpacket.data))
             offset += sub_len
             self.subpackets.append(subpacket)
 

--- a/pgpdump/packet.py
+++ b/pgpdump/packet.py
@@ -683,10 +683,16 @@ class UserAttributePacket(Packet):
             # there is only one currently known type- images (1)
             if sub_type == 1:
                 # the only little-endian encoded value in OpenPGP
+                if len(self.data) <= (offset + 3):
+                    raise PgpdumpException("Needs 4-octet attribute header at position %d of packet size %d"%(offset, len(self.data)))
                 hdr_size = self.data[offset] + (self.data[offset + 1] << 8)
                 hdr_version = self.data[offset + 2]
                 self.raw_image_format = self.data[offset + 3]
+                if len(self.data) <= (offset + hdr_size):
+                    raise PgpdumpException("Claimed attribute header has %d octets at position %d of packet size %d"%(hdr_size, offset, len(self.data)))
                 offset += hdr_size
+                # FIXME: ensure that the reserved octets of the header are all-zeros
+                # (see https://tools.ietf.org/html/rfc4880#section-5.12.1)
 
                 self.image_data = self.data[offset:]
                 if self.raw_image_format == 1:

--- a/pgpdump/packet.py
+++ b/pgpdump/packet.py
@@ -421,12 +421,9 @@ class PublicKeyPacket(Packet, AlgoLookup):
             self.prime, offset = get_mpi(self.data, offset)
             self.group_gen, offset = get_mpi(self.data, offset)
             self.key_value, offset = get_mpi(self.data, offset)
-        elif 100 <= self.raw_pub_algorithm <= 110:
-            # Private/Experimental algorithms, just move on
-            pass
         else:
-            raise PgpdumpException("Unsupported public key algorithm %d" %
-                    self.raw_pub_algorithm)
+            # If we don't know how to handle the algorithm, just move on
+            pass
 
         return offset
 
@@ -610,12 +607,9 @@ class SecretKeyPacket(PublicKeyPacket):
             self.pub_algorithm_type = "elg"
             # x
             self.exponent_x, offset = get_mpi(self.data, offset)
-        elif 100 <= self.raw_pub_algorithm <= 110:
-            # Private/Experimental algorithms, just move on
-            pass
         else:
-            raise PgpdumpException("Unsupported public key algorithm %d" %
-                    self.raw_pub_algorithm)
+            # If we don't know how to handle the algorithm, just move on
+            pass
 
         return offset
 

--- a/pgpdump/packet.py
+++ b/pgpdump/packet.py
@@ -773,6 +773,8 @@ def new_tag_length(data, start):
     look. Returns a derived (offset, length, partial) tuple.
     Reference: http://tools.ietf.org/html/rfc4880#section-4.2.2
     '''
+    if len(data) <= start:
+        raise PgpdumpException("new_tag_length at start %d of packet of length %d"%(start, len(data)))
     first = data[start]
     offset = length = 0
     partial = False

--- a/pgpdump/utils.py
+++ b/pgpdump/utils.py
@@ -71,17 +71,26 @@ def crc24(data):
 
 def get_int2(data, offset):
     '''Pull two bytes from data at offset and return as an integer.'''
+    if offset+2 > len(data):
+        raise PgpdumpException("Wants a 2-byte integer at position %d of packet of size %d"%(
+            offset, len(data)))
     return (data[offset] << 8) + data[offset + 1]
 
 
 def get_int4(data, offset):
     '''Pull four bytes from data at offset and return as an integer.'''
+    if offset+4 > len(data):
+        raise PgpdumpException("Wants a 4-byte integer at position %d of packet of size %d"%(
+            offset, len(data)))
     return ((data[offset] << 24) + (data[offset + 1] << 16) +
             (data[offset + 2] << 8) + data[offset + 3])
 
 
 def get_int8(data, offset):
     '''Pull eight bytes from data at offset and return as an integer.'''
+    if offset+8 > len(data):
+        raise PgpdumpException("Wants an 8-byte integer at position %d of packet of size %d"%(
+            offset, len(data)))
     return (get_int4(data, offset) << 32) + get_int4(data, offset + 4)
 
 

--- a/pgpdump/utils.py
+++ b/pgpdump/utils.py
@@ -92,6 +92,8 @@ def get_mpi(data, offset):
     mpi_len = get_int2(data, offset)
     offset += 2
     to_process = (mpi_len + 7) // 8
+    if to_process > (len(data) - offset):
+        raise PgpdumpException("MPI wants %s octets, but buffer has only %s left"%(to_process, len(data) - offset))
     mpi = 0
     i = -4
     for i in range(0, to_process - 3, 4):


### PR DESCRIPTION
This series of changes does significantly more error checking, and tries to avoid arbitrary exceptions being thrown when handling malformed data.

It also permits the user to use the system `logging` module when parsing a stream of packets to log malformed packets rather than raising an exception during the generation.

Part of this cleanup also involves identifying new algorithms and packet types.